### PR TITLE
Fix max health issue in HG thread

### DIFF
--- a/src/main/java/tk/shanebee/hg/game/Game.java
+++ b/src/main/java/tk/shanebee/hg/game/Game.java
@@ -7,6 +7,7 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.WorldBorder;
+import org.bukkit.attribute.Attribute;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
@@ -850,7 +851,7 @@ public class Game {
         for (PotionEffect ef : player.getActivePotionEffects()) {
             player.removePotionEffect(ef.getType());
         }
-        player.setHealth(20);
+        player.setHealth(player.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue());
         player.setFoodLevel(20);
         BukkitRunnable runnable = new BukkitRunnable() {
             @Override

--- a/src/main/java/tk/shanebee/hg/listeners/GameListener.java
+++ b/src/main/java/tk/shanebee/hg/listeners/GameListener.java
@@ -4,6 +4,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.attribute.Attribute;
 import org.bukkit.block.Block;
 import org.bukkit.block.ShulkerBox;
 import org.bukkit.block.Sign;
@@ -210,7 +211,7 @@ public class GameListener implements Listener {
 
     private void processDeath(Player player, Game game, Entity damager, EntityDamageEvent.DamageCause cause) {
         dropInv(player);
-        player.setHealth(20);
+        player.setHealth(player.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue());
         BukkitRunnable run = new BukkitRunnable() {
             @Override
             public void run() {

--- a/src/main/java/tk/shanebee/hg/tasks/FreeRoamTask.java
+++ b/src/main/java/tk/shanebee/hg/tasks/FreeRoamTask.java
@@ -3,6 +3,7 @@ package tk.shanebee.hg.tasks;
 import java.util.UUID;
 
 import org.bukkit.Bukkit;
+import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.Player;
 
 import org.bukkit.scheduler.BukkitRunnable;
@@ -24,7 +25,7 @@ public class FreeRoamTask extends BukkitRunnable {
 			if (p != null) {
 				Util.scm(p, started);
 				Util.scm(p, roam_time.replace("<roam>", String.valueOf(roam_t)));
-				p.setHealth(20);
+				p.setHealth(p.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue());
 				p.setFoodLevel(20);
 				g.unFreeze(p);
 			}


### PR DESCRIPTION
Link to post: https://www.spigotmc.org/threads/hungergames.365515/page-12#post-3816828
The issue was: java.lang.IllegalArgumentException: Health must be between 0 and 18.0, but was 20.0.

It seems the issue is caused by setting the health to 20 after the user has used another plugin or status effect to lower the max health.  This solution was the first thing that came to mind if the user is trying to change the behavior inside the HG match.  I don't know if you might want to just save and load the max health instead.