### PR TITLE
Added options to choose which containers are bonus chest

### DIFF
--- a/src/main/java/tk/shanebee/hg/data/Config.java
+++ b/src/main/java/tk/shanebee/hg/data/Config.java
@@ -29,6 +29,9 @@ public class Config {
     public static int minchestcontent;
     public static int maxbonuscontent;
     public static int minbonuscontent;
+    public static boolean shulkerBoxIsBonusChest;
+    public static boolean trappedChestIsBonusChest;
+    public static boolean barrelIsBonusChest;
     public static int maxTeam;
     public static boolean teleportEnd;
     public static int teleportEndTime;
@@ -106,6 +109,9 @@ public class Config {
         minchestcontent = config.getInt("settings.min-chestcontent");
         maxbonuscontent = config.getInt("settings.max-bonus-chestcontent");
         minbonuscontent = config.getInt("settings.min-bonus-chestcontent");
+        shulkerBoxIsBonusChest = config.getBoolean("settings.use-shulkerbox-for-bonuschest");
+        trappedChestIsBonusChest = config.getBoolean("settings.use-trappedchest-for-bonuschest");
+        barrelIsBonusChest = config.getBoolean("settings.use-barrel-for-bonuschest");
         maxTeam = config.getInt("settings.max-team-size");
         giveReward = config.getBoolean("reward.enabled");
         cash = config.getInt("reward.cash");

--- a/src/main/java/tk/shanebee/hg/listeners/GameListener.java
+++ b/src/main/java/tk/shanebee/hg/listeners/GameListener.java
@@ -377,10 +377,10 @@ public class GameListener implements Listener {
 			if (block.getType() == Material.CHEST) {
 				Bukkit.getServer().getPluginManager().callEvent(new ChestOpenEvent(pd.getGame(), block, false));
 			}
-			if (block.getType() == Material.TRAPPED_CHEST || block.getState() instanceof ShulkerBox) {
+			if ((Config.trappedChestIsBonusChest && block.getType() == Material.TRAPPED_CHEST) || (Config.shulkerBoxIsBonusChest && block.getState() instanceof ShulkerBox)) {
 				Bukkit.getServer().getPluginManager().callEvent(new ChestOpenEvent(pd.getGame(), block, true));
 			}
-			if (Util.isRunningMinecraft(1, 14) && block.getType() == Material.BARREL) {
+			if (Config.barrelIsBonusChest && Util.isRunningMinecraft(1, 14) && block.getType() == Material.BARREL) {
 					Bukkit.getServer().getPluginManager().callEvent(new ChestOpenEvent(pd.getGame(), block, true));
 			}
 		}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -24,6 +24,12 @@ settings:
     # Maximum/Minimum amount of items that will spawn in bonus chests
     max-bonus-chestcontent: 5
     min-bonus-chestcontent: 1
+    # If shulker boxes wil be treated as bonus chests
+    use-shulkerbox-for-bonuschest: true
+    # If trapped chests wil be treated as bonus chests
+    use-trappedchest-for-bonuschest: true
+    # If barrels wil be treated as bonus chests
+    use-barrel-for-bonuschest: true
     # When the game has x seconds left, teleport the players back to their starting point
     teleport-at-end: false
     # The time in seconds to teleport players back to their starting point


### PR DESCRIPTION
Added config options to individually disable shulker boxes, trapped chests, and/or barrels as bonus chests.