### PR TITLE
teleport players to their previous location

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>tk.shanebee.hg</groupId>
     <artifactId>HungerGames</artifactId>
-    <version>4.15.1</version>
+    <version>4.15.2</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/src/main/java/tk/shanebee/hg/data/Config.java
+++ b/src/main/java/tk/shanebee/hg/data/Config.java
@@ -35,6 +35,7 @@ public class Config {
     public static int teleportEndTime;
     public static List<String> bonusBlockTypes;
     public static boolean hideNametags;
+    public static boolean tpBack;
 
     //Team info
     public static boolean team_showTeamNames;
@@ -107,7 +108,8 @@ public class Config {
 
     private void loadConfig() {
         debug = config.getBoolean("settings.debug");
-        spawnmobs = config.getBoolean("settings.spawn-mobs");
+        tpBack = config.getBoolean("settings.tp-back");
+        spawnmobs = config.getBoolean("settings.spawn-mobs") ;
         spawnmobsinterval = config.getInt("settings.spawn-mobs-interval") * 20;
         bossbar = config.getBoolean("settings.bossbar-countdown");
         trackingstickuses = config.getInt("settings.trackingstick-uses");

--- a/src/main/java/tk/shanebee/hg/data/PlayerData.java
+++ b/src/main/java/tk/shanebee/hg/data/PlayerData.java
@@ -2,6 +2,7 @@ package tk.shanebee.hg.data;
 
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
+import org.bukkit.Location;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -31,6 +32,7 @@ public class PlayerData implements Cloneable {
     private final GameMode mode;
     private final UUID uuid;
     private final Scoreboard scoreboard;
+    private final Location previousLocation;
 
     //InGame data
     private Team team;
@@ -39,11 +41,11 @@ public class PlayerData implements Cloneable {
 
     /**
      * New player pre-game data file
-     *
-     * @param player Player to save
+     *  @param player Player to save
      * @param game   Game they will be entering
+     * @param oldLoc
      */
-    public PlayerData(Player player, Game game) {
+    public PlayerData(Player player, Game game, Location oldLoc) {
         this.game = game;
         this.uuid = player.getUniqueId();
         inv = player.getInventory().getStorageContents();
@@ -58,6 +60,7 @@ public class PlayerData implements Cloneable {
         player.setLevel(0);
         player.setExp(0);
         scoreboard = player.getScoreboard();
+        previousLocation = oldLoc;
     }
 
     /**
@@ -164,6 +167,15 @@ public class PlayerData implements Cloneable {
      */
     public UUID getUuid() {
         return this.uuid;
+    }
+
+    /**
+     * Get previous location of this player data
+     *
+     * @return previous location of this player data
+     */
+    public Location getPreviousLocation() {
+        return this.previousLocation;
     }
 
     /**

--- a/src/main/java/tk/shanebee/hg/game/Game.java
+++ b/src/main/java/tk/shanebee/hg/game/Game.java
@@ -292,9 +292,9 @@ public class Game {
             if (player != null) {
                 gamePlayerData.heal(player);
                 playerManager.getPlayerData(uuid).restore(player);
-                playerManager.removePlayerData(uuid);
                 win.add(uuid);
                 gamePlayerData.exit(player);
+                playerManager.removePlayerData(uuid);
             }
         }
         gamePlayerData.clearPlayers();

--- a/src/main/java/tk/shanebee/hg/game/GamePlayerData.java
+++ b/src/main/java/tk/shanebee/hg/game/GamePlayerData.java
@@ -328,9 +328,9 @@ public class GamePlayerData extends Data {
         }else if (gameArenaData.exit != null && gameArenaData.exit.getWorld() != null) {
                 player.teleport(gameArenaData.exit);
         } else {
-                Location worldSpawn = Bukkit.getWorlds().get(0).getSpawnLocation();
-                Location bedLocation = player.getBedSpawnLocation();
-                player.teleport(bedLocation != null ? bedLocation : worldSpawn);
+            Location worldSpawn = Bukkit.getWorlds().get(0).getSpawnLocation();
+            Location bedLocation = player.getBedSpawnLocation();
+            player.teleport(bedLocation != null ? bedLocation : worldSpawn);
         }
 
     }

--- a/src/main/java/tk/shanebee/hg/managers/PlayerManager.java
+++ b/src/main/java/tk/shanebee/hg/managers/PlayerManager.java
@@ -8,6 +8,7 @@ import tk.shanebee.hg.game.Game;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * General player manager

--- a/src/main/java/tk/shanebee/hg/managers/PlayerManager.java
+++ b/src/main/java/tk/shanebee/hg/managers/PlayerManager.java
@@ -8,7 +8,6 @@ import tk.shanebee.hg.game.Game;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * General player manager

--- a/src/main/java/tk/shanebee/hg/tasks/StartingTask.java
+++ b/src/main/java/tk/shanebee/hg/tasks/StartingTask.java
@@ -2,10 +2,8 @@ package tk.shanebee.hg.tasks;
 
 import org.bukkit.Bukkit;
 
-import tk.shanebee.hg.data.Config;
 import tk.shanebee.hg.game.Game;
 import tk.shanebee.hg.HG;
-import tk.shanebee.hg.managers.PlayerManager;
 import tk.shanebee.hg.util.Util;
 
 public class StartingTask implements Runnable {
@@ -13,7 +11,6 @@ public class StartingTask implements Runnable {
 	private int timer;
 	private int id;
 	private Game game;
-	private PlayerManager playerManager;
 
 	public StartingTask(Game g) {
 		this.timer = 30;
@@ -23,7 +20,6 @@ public class StartingTask implements Runnable {
 				.replace("<arena>", name)
 				.replace("<seconds>", "" + timer));
 		Util.broadcast(HG.getPlugin().getLang().game_join.replace("<arena>", name));
-		this.playerManager = HG.getPlugin().getPlayerManager();
 		this.id = Bukkit.getScheduler().scheduleSyncRepeatingTask(HG.getPlugin(), this, 5 * 20L, 5 * 20L);
 	}
 

--- a/src/main/java/tk/shanebee/hg/tasks/StartingTask.java
+++ b/src/main/java/tk/shanebee/hg/tasks/StartingTask.java
@@ -2,8 +2,10 @@ package tk.shanebee.hg.tasks;
 
 import org.bukkit.Bukkit;
 
+import tk.shanebee.hg.data.Config;
 import tk.shanebee.hg.game.Game;
 import tk.shanebee.hg.HG;
+import tk.shanebee.hg.managers.PlayerManager;
 import tk.shanebee.hg.util.Util;
 
 public class StartingTask implements Runnable {
@@ -11,6 +13,7 @@ public class StartingTask implements Runnable {
 	private int timer;
 	private int id;
 	private Game game;
+	private PlayerManager playerManager;
 
 	public StartingTask(Game g) {
 		this.timer = 30;
@@ -20,7 +23,7 @@ public class StartingTask implements Runnable {
 				.replace("<arena>", name)
 				.replace("<seconds>", "" + timer));
 		Util.broadcast(HG.getPlugin().getLang().game_join.replace("<arena>", name));
-
+		this.playerManager = HG.getPlugin().getPlayerManager();
 		this.id = Bukkit.getScheduler().scheduleSyncRepeatingTask(HG.getPlugin(), this, 5 * 20L, 5 * 20L);
 	}
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -16,6 +16,8 @@ settings:
     # If mobs will spawn in the arena, and their interval
     spawn-mobs: true
     spawn-mobs-interval: 35
+    # TP the player to his previous location when leaving the arena
+    tp-back: false
     # The time once the game starts, how long they are safe from PvP (In seconds)
     free-roam: 25
     # Whether or not to show a countdown bossbar in game


### PR DESCRIPTION
This feature saves the player's location before him entering the arena. 

It will tp him back to his pre-join location on arena exit.

It can be activated in config via **tp-back** option (default to false)