### PR TITLE
Bugfix: Players rarely able to move away from HG Spawnpoints before Game Start.

### DIFF
--- a/src/main/java/tk/shanebee/hg/game/GamePlayerData.java
+++ b/src/main/java/tk/shanebee/hg/game/GamePlayerData.java
@@ -138,7 +138,7 @@ public class GamePlayerData extends Data {
      * @param player Player to freeze
      */
     public void freeze(Player player) {
-        player.setGameMode(GameMode.SURVIVAL);
+        player.setGameMode(GameMode.ADVENTURE); //Change to Adventure mode instead of Survival, to prevent moving by breaking blocks which get cancelled breaking before the game starts.
         player.addPotionEffect(new PotionEffect(PotionEffectType.JUMP, 23423525, -10, false, false));
         player.setWalkSpeed(0.0001F);
         player.setFoodLevel(1);
@@ -153,6 +153,7 @@ public class GamePlayerData extends Data {
      * @param player Player to unfreeze
      */
     public void unFreeze(Player player) {
+        player.setGameMode(GameMode.SURVIVAL); //Change back to Survival Mode.
         player.removePotionEffect(PotionEffectType.JUMP);
         player.setWalkSpeed(0.2F);
     }
@@ -304,6 +305,16 @@ public class GamePlayerData extends Data {
                 heal(player);
                 freeze(player);
                 kills.put(player, 0);
+
+                // Sometimes, when joining from a different world or unloaded chunks using e.g. Multiverse plugins,
+                // after the first teleportation you are still able to make 1 last jump at the spawnpoint when joining via
+                // a Sign, from the velocity you have at the moment just before joining. This can happen because of server lag for example.
+                // You are then able to get closer to the middle while the game did not yet start and you are not placed
+                // properly on the spawn point. Therefore, I included an extra teleport to make sure everyone for sure is at the beginning before game start.
+                // I could not think of a smarter way to resolve this issue and I really needed it to be able to player HungerGames
+                // without any problems. There must however be smarter ways to resolve this issue. (Resetting player velocity did not work :c.)
+                // I might as well not fully understand the issue, I only know it occurs and how to reproduce it.
+                PaperLib.teleportAsync(player, loc);
 
                 if (players.size() == 1 && status == Status.READY)
                     gameArenaData.setStatus(Status.WAITING);

--- a/src/main/java/tk/shanebee/hg/game/GamePlayerData.java
+++ b/src/main/java/tk/shanebee/hg/game/GamePlayerData.java
@@ -138,7 +138,9 @@ public class GamePlayerData extends Data {
      * @param player Player to freeze
      */
     public void freeze(Player player) {
-        player.setGameMode(GameMode.ADVENTURE); //Change to Adventure mode instead of Survival, to prevent moving by breaking blocks which get cancelled breaking before the game starts.
+        // Change to Adventure mode instead of Survival, to prevent moving by breaking blocks which get cancelled breaking before the game starts.
+        // In order to make the gamemode switch work with Multiverse as well, only change it 2 ticks later.
+        Bukkit.getServer().getScheduler().scheduleSyncDelayedTask(plugin, () -> player.setGameMode(GameMode.ADVENTURE), 2l);
         player.addPotionEffect(new PotionEffect(PotionEffectType.JUMP, 23423525, -10, false, false));
         player.setWalkSpeed(0.0001F);
         player.setFoodLevel(1);


### PR DESCRIPTION
This PR Fixes a strange bug where players were sometimes able to move away from the HG Spawn platforms before the game started.
This could be done by joining from a different world, via signs and then jumping before the join.
Once the player got TP'ed into the arena, they sometimes got 1 last jump before the potion effect applied and because of the velocity they still had, they moved more into the middle, closer to chests.
It is hard to reproduce on a localhost server, but it can occur on servers with some more server lagspikes and multiverse installed.

Also, it was possible to break the block the player was standing on (e.g. Glowstone) and move this way, because of the block breaking being cancelled and the player kind of 'falling' for a short while and then moving.

This is an quick and easy change, al though it might not be the most logical one.
Feel free to change things if needed. :)

I did test this however on my live server and it does resolve the aforementioned issue.