### PR TITLE
update dependencies for 1.18.2 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
             <url>https://papermc.io/repo/repository/maven-public/</url>
         </repository>
         <repository>
-            <id>placeholderapi</id>
+            <id>placeholderapi-repo</id>
             <url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>tk.shanebee.hg</groupId>
     <artifactId>HungerGames</artifactId>
-    <version>4.15.6</version>
+    <version>4.15.7-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         </repository>
         <repository>
             <id>placeholderapi-repo</id>
-            <url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+            <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
         <repository>
             <id>CodeMC</id>

--- a/pom.xml
+++ b/pom.xml
@@ -35,31 +35,36 @@
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>
+        <repository>
+            <id>nexus</id>
+            <name>Lumine Releases</name>
+            <url>https://mvn.lumine.io/repository/maven-public/</url>
+        </repository>
     </repositories>
 
     <dependencies>
         <dependency>
-            <groupId>com.destroystokyo.paper</groupId>
+            <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.16.4-R0.1-SNAPSHOT</version>
+            <version>1.18.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.papermc</groupId>
             <artifactId>paperlib</artifactId>
-            <version>1.0.6</version>
+            <version>1.0.7</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.10.4</version>
+            <version>2.10.10</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>net.milkbowl.vault</groupId>
+            <groupId>com.github.milkbowl</groupId>
             <artifactId>VaultAPI</artifactId>
-            <version>1.7</version>
+            <version>1.7.1</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -69,10 +74,10 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.github.tr7zw.Item-NBT-API</groupId>
+            <groupId>de.tr7zw</groupId>
             <artifactId>item-nbt-api</artifactId>
             <!--suppress MavenModelInspection -->
-            <version>2.8.0</version>
+            <version>2.9.0-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -91,7 +96,7 @@
         <dependency>
             <groupId>com.gmail.nossr50.mcMMO</groupId>
             <artifactId>mcMMO</artifactId>
-            <version>2.1.108</version>
+            <version>2.1.200</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -111,9 +116,8 @@
         <dependency>
             <groupId>io.lumine.xikage</groupId>
             <artifactId>MythicMobs</artifactId>
-            <version>4.6.5</version>
-            <scope>system</scope>
-            <systemPath>${project.basedir}/libs/MythicMobs-4.6.5.jar</systemPath>
+            <version>4.11.0-BETA</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.18.1-R0.1-SNAPSHOT</version>
+            <version>1.18.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -77,7 +77,7 @@
             <groupId>de.tr7zw</groupId>
             <artifactId>item-nbt-api</artifactId>
             <!--suppress MavenModelInspection -->
-            <version>2.9.0-SNAPSHOT</version>
+            <version>2.9.2-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/src/main/java/tk/shanebee/hg/HG.java
+++ b/src/main/java/tk/shanebee/hg/HG.java
@@ -2,7 +2,6 @@ package tk.shanebee.hg;
 
 import io.lumine.xikage.mythicmobs.MythicMobs;
 import io.lumine.xikage.mythicmobs.mobs.MobManager;
-import io.papermc.lib.PaperLib;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;

--- a/src/main/java/tk/shanebee/hg/commands/BorderTimerCmd.java
+++ b/src/main/java/tk/shanebee/hg/commands/BorderTimerCmd.java
@@ -1,7 +1,6 @@
 package tk.shanebee.hg.commands;
 
 import tk.shanebee.hg.game.Game;
-import tk.shanebee.hg.HG;
 import tk.shanebee.hg.util.Util;
 
 public class BorderTimerCmd extends BaseCmd {

--- a/src/main/java/tk/shanebee/hg/commands/ChestRefillCmd.java
+++ b/src/main/java/tk/shanebee/hg/commands/ChestRefillCmd.java
@@ -1,7 +1,6 @@
 package tk.shanebee.hg.commands;
 
 import tk.shanebee.hg.game.Game;
-import tk.shanebee.hg.HG;
 import tk.shanebee.hg.util.Util;
 
 public class ChestRefillCmd extends BaseCmd {

--- a/src/main/java/tk/shanebee/hg/commands/ChestRefillNowCmd.java
+++ b/src/main/java/tk/shanebee/hg/commands/ChestRefillNowCmd.java
@@ -1,6 +1,5 @@
 package tk.shanebee.hg.commands;
 
-import tk.shanebee.hg.HG;
 import tk.shanebee.hg.Status;
 import tk.shanebee.hg.game.Game;
 import tk.shanebee.hg.util.Util;

--- a/src/main/java/tk/shanebee/hg/commands/CreateCmd.java
+++ b/src/main/java/tk/shanebee/hg/commands/CreateCmd.java
@@ -2,7 +2,6 @@ package tk.shanebee.hg.commands;
 
 import tk.shanebee.hg.game.Bound;
 import tk.shanebee.hg.game.Game;
-import tk.shanebee.hg.HG;
 import tk.shanebee.hg.data.PlayerSession;
 import tk.shanebee.hg.util.Util;
 

--- a/src/main/java/tk/shanebee/hg/commands/DebugCmd.java
+++ b/src/main/java/tk/shanebee/hg/commands/DebugCmd.java
@@ -1,7 +1,5 @@
 package tk.shanebee.hg.commands;
 
-import tk.shanebee.hg.HG;
-
 public class DebugCmd extends BaseCmd {
 
 	public DebugCmd() {

--- a/src/main/java/tk/shanebee/hg/commands/DeleteCmd.java
+++ b/src/main/java/tk/shanebee/hg/commands/DeleteCmd.java
@@ -1,7 +1,6 @@
 package tk.shanebee.hg.commands;
 
 import tk.shanebee.hg.game.Game;
-import tk.shanebee.hg.HG;
 import tk.shanebee.hg.Status;
 import tk.shanebee.hg.game.GameArenaData;
 import tk.shanebee.hg.game.GamePlayerData;

--- a/src/main/java/tk/shanebee/hg/commands/ListGamesCmd.java
+++ b/src/main/java/tk/shanebee/hg/commands/ListGamesCmd.java
@@ -1,7 +1,6 @@
 package tk.shanebee.hg.commands;
 
 import tk.shanebee.hg.game.Game;
-import tk.shanebee.hg.HG;
 import tk.shanebee.hg.game.GameArenaData;
 import tk.shanebee.hg.util.Util;
 

--- a/src/main/java/tk/shanebee/hg/commands/NBTCmd.java
+++ b/src/main/java/tk/shanebee/hg/commands/NBTCmd.java
@@ -5,7 +5,6 @@ import org.bukkit.Material;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-import tk.shanebee.hg.HG;
 import tk.shanebee.hg.util.Util;
 import tk.shanebee.hg.util.NBTApi;
 

--- a/src/main/java/tk/shanebee/hg/commands/SetLobbyWallCmd.java
+++ b/src/main/java/tk/shanebee/hg/commands/SetLobbyWallCmd.java
@@ -5,7 +5,6 @@ import org.bukkit.block.Block;
 import org.bukkit.block.Sign;
 
 import tk.shanebee.hg.game.Game;
-import tk.shanebee.hg.HG;
 import tk.shanebee.hg.util.Util;
 
 public class SetLobbyWallCmd extends BaseCmd {

--- a/src/main/java/tk/shanebee/hg/commands/SpectateCmd.java
+++ b/src/main/java/tk/shanebee/hg/commands/SpectateCmd.java
@@ -1,7 +1,6 @@
 package tk.shanebee.hg.commands;
 
 import tk.shanebee.hg.game.Game;
-import tk.shanebee.hg.HG;
 import tk.shanebee.hg.Status;
 import tk.shanebee.hg.game.GamePlayerData;
 import tk.shanebee.hg.util.Util;

--- a/src/main/java/tk/shanebee/hg/commands/StartCmd.java
+++ b/src/main/java/tk/shanebee/hg/commands/StartCmd.java
@@ -1,7 +1,6 @@
 package tk.shanebee.hg.commands;
 
 import tk.shanebee.hg.game.Game;
-import tk.shanebee.hg.HG;
 import tk.shanebee.hg.Status;
 import tk.shanebee.hg.util.Util;
 

--- a/src/main/java/tk/shanebee/hg/commands/StopCmd.java
+++ b/src/main/java/tk/shanebee/hg/commands/StopCmd.java
@@ -1,7 +1,6 @@
 package tk.shanebee.hg.commands;
 
 import tk.shanebee.hg.game.Game;
-import tk.shanebee.hg.HG;
 import tk.shanebee.hg.Status;
 import tk.shanebee.hg.util.Util;
 

--- a/src/main/java/tk/shanebee/hg/commands/ToggleCmd.java
+++ b/src/main/java/tk/shanebee/hg/commands/ToggleCmd.java
@@ -1,7 +1,6 @@
 package tk.shanebee.hg.commands;
 
 import tk.shanebee.hg.game.Game;
-import tk.shanebee.hg.HG;
 import tk.shanebee.hg.Status;
 import tk.shanebee.hg.game.GameArenaData;
 import tk.shanebee.hg.util.Util;

--- a/src/main/java/tk/shanebee/hg/managers/KillManager.java
+++ b/src/main/java/tk/shanebee/hg/managers/KillManager.java
@@ -8,7 +8,6 @@ import org.bukkit.entity.Projectile;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import tk.shanebee.hg.HG;
 import tk.shanebee.hg.data.Language;
-import tk.shanebee.hg.util.Util;
 
 /**
  * Manager for deaths in game

--- a/src/main/java/tk/shanebee/hg/util/NBTApi.java
+++ b/src/main/java/tk/shanebee/hg/util/NBTApi.java
@@ -3,7 +3,6 @@ package tk.shanebee.hg.util;
 import de.tr7zw.changeme.nbtapi.NBTContainer;
 import de.tr7zw.changeme.nbtapi.NBTItem;
 import de.tr7zw.changeme.nbtapi.utils.MinecraftVersion;
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 


### PR DESCRIPTION
Updates to plugin dependencies in pom.xml to add support for 1.18.1 including
- nbt-api 1.18.1 support
- provide public repo for mythic mobs
- papermc new groupId

Not sure if this will be merged as the plugin is (hopefully temporarily) no longer supported, but may be useful to someone.