### PR TITLE
Fix for #114

### DIFF
--- a/src/main/java/com/shanebeestudios/hg/api/game/GameBorderData.java
+++ b/src/main/java/com/shanebeestudios/hg/api/game/GameBorderData.java
@@ -38,8 +38,8 @@ public class GameBorderData extends Data {
         super(game);
         this.gamePlayerData = game.getGamePlayerData();
         this.worldBorder = Bukkit.createWorldBorder();
-	if(centerLocations != null)
-        	this.centerLocations.add(centerLocations);
+        if(centerLocations != null)
+            this.centerLocations.add(centerLocations);
         this.finalBorderSize = finalSize;
         this.borderCountdownStart = start;
         this.borderCountdownEnd = end;

--- a/src/main/java/com/shanebeestudios/hg/api/game/GameBorderData.java
+++ b/src/main/java/com/shanebeestudios/hg/api/game/GameBorderData.java
@@ -38,7 +38,8 @@ public class GameBorderData extends Data {
         super(game);
         this.gamePlayerData = game.getGamePlayerData();
         this.worldBorder = Bukkit.createWorldBorder();
-        this.centerLocations.add(centerLocations);
+	if(centerLocations != null)
+        	this.centerLocations.add(centerLocations);
         this.finalBorderSize = finalSize;
         this.borderCountdownStart = start;
         this.borderCountdownEnd = end;


### PR DESCRIPTION
<!-- Before opening a pull request to add a new feature, make sure this feature is approved by the team. -->
## Describe your changes
<!-- Describe your changes here. The more details the better! -->

Added a check in the `GameBorderData` constructor that prevents `centerLocations` from becoming `[null]` instead of simply `null` which caused a bug where `resetBorder()` would not follow the `this.centerLocations.isEmpty()` path when it should have, causing a NullPointerException and arena-breaking in-game behaviour (broken countdown, no pvp, player immortality).

I'm not sure how this bug came to be as it seems impossible to avoid, possibly a change in truth-value behavior across java versions?

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Any required server software, such as Paper?-->
**Related Issues:** [#114 ](https://github.com/ShaneBeeStudios/HungerGames/issues/114) <!-- Link[s] to related issues -->

## Checklist before requesting a review
- [ Somewhat... I maintained style and there was only one branch available to PR] I have read the [contributing guidelines](https://github.com/ShaneBeeStudios/HungerGames/blob/master/.github/contributing.md)
- Thanks for considering my PR I think it fixes a genuine bug -- I am not a regular open source contributor so sorry if I've done something wrong here plz lmk how I can fix ty
- See attached a plain .patch for this
[0001-null-centerLocations-causing-a-truthy-branch-in-Game.patch](https://github.com/user-attachments/files/31064071/0001-null-centerLocations-causing-a-truthy-branch-in-Game.patch)
